### PR TITLE
Soporte para Arduino UNO R4 Minima

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,3 +14,10 @@ board = wemos_d1_uno32
 framework = arduino
 lib_deps = 
     adafruit/Adafruit NeoPixel@^1.12.0
+
+[env:r4_minima]
+platform = renesas-ra
+board = uno_r4_minima
+framework = arduino
+lib_deps = 
+    https://github.com/adafruit/Adafruit_NeoPixel.git

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,12 @@
 #include <Arduino.h>
 #include <Adafruit_NeoPixel.h>
 
-#define PIN           GPIO_NUM_26 //  Pin donde tengo conectado DIN
+#if defined(ARDUINO_UNOR4_MINIMA)
+  #define PIN           PIN_D2
+#elif defined(ARDUINO_D1_UNO32)
+  #define PIN           GPIO_NUM_26
+#endif
+
 #define NUM_LEDS      16          //  Numero de leds del anillo
 #define WAIT          75          //  Delay de barrido de leds
 #define WAIT_RAINBOW  10          //  Delay de efecto arcoiris


### PR DESCRIPTION
He agregado soporte por medio de un ENV para la placa arduino uno r4 Minimia y modificado el archivo main.cpp con sus respectivos macros y directivas de preprocesador para que no rompan compatilibad con la placa D1 R32.